### PR TITLE
Dev yyang Add the ability to delete templates. Prevent duplicate template names. 

### DIFF
--- a/src/main/java/gov/epa/bencloud/api/CoreApi.java
+++ b/src/main/java/gov/epa/bencloud/api/CoreApi.java
@@ -2,6 +2,7 @@ package gov.epa.bencloud.api;
 
 import static gov.epa.bencloud.server.database.jooq.data.Tables.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.jooq.DSLContext;
@@ -25,6 +26,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import gov.epa.bencloud.Constants;
 import gov.epa.bencloud.server.database.JooqUtil;
 import gov.epa.bencloud.server.database.jooq.data.tables.records.TaskConfigRecord;
+import gov.epa.bencloud.api.util.ApiUtil;
 
 import spark.Request;
 import spark.Response;
@@ -129,6 +131,14 @@ public class CoreApi {
 			e.printStackTrace();
 			response.status(400);
 			return null;
+		}
+		
+		//make sure the new task name is unique among this user's tasks
+		List<String>taskNames = ApiUtil.getAllTaskNamesByUser(userProfile.get().getId());
+		if (taskNames.contains(name.toLowerCase())) {
+			response.status(400);
+			String errorMsg = "A task named " + name + " already exists. Please enter a different name.";			
+			return errorMsg;
 		}
 		
 		

--- a/src/main/java/gov/epa/bencloud/api/CoreApi.java
+++ b/src/main/java/gov/epa/bencloud/api/CoreApi.java
@@ -5,12 +5,14 @@ import static gov.epa.bencloud.server.database.jooq.data.Tables.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
 import org.jooq.JSON;
 import org.jooq.JSONFormat;
 import org.jooq.Result;
 import org.jooq.JSONFormat.RecordFormat;
 import org.jooq.Record;
+import org.jooq.Record1;
 import org.jooq.impl.DSL;
 import org.pac4j.core.profile.UserProfile;
 import org.slf4j.LoggerFactory;
@@ -25,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import gov.epa.bencloud.Constants;
 import gov.epa.bencloud.server.database.JooqUtil;
+import gov.epa.bencloud.server.database.jooq.data.tables.records.AirQualityLayerRecord;
 import gov.epa.bencloud.server.database.jooq.data.tables.records.TaskConfigRecord;
 import gov.epa.bencloud.api.util.ApiUtil;
 
@@ -92,6 +95,38 @@ public class CoreApi {
 	
 
 	//TODO: Add deleteTaskConfig, update?
+	public static Object deleteTaskConfig(Request request, Response response, Optional<UserProfile> userProfile) {
+		Integer id;
+		try {
+			id = Integer.valueOf(request.params("id"));
+		} catch (NumberFormatException e) {
+			e.printStackTrace();
+			return CoreApi.getErrorResponseInvalidId(request, response);
+		}
+		
+		
+		//Users can only delete templates created by themselves 		
+		DSLContext create = DSL.using(JooqUtil.getJooqConfiguration());	
+		Result<Record1<Integer>> res = create.select(TASK_CONFIG.ID)
+				.from(TASK_CONFIG)
+				.where(TASK_CONFIG.USER_ID.eq(userProfile.get().getId()))
+				.and(TASK_CONFIG.ID.eq(id))
+				.fetch();
+		
+		if(res==null) {
+			return CoreApi.getErrorResponseForbidden(request, response);
+		}		
+		
+		int configRows = create.deleteFrom(TASK_CONFIG).where(TASK_CONFIG.ID.eq(id)).execute();
+		
+		if(configRows == 0) {
+			return CoreApi.getErrorResponse(request, response, 400, "Unknown error");
+		} else {
+			response.status(204);
+			return response;
+		}
+		
+	}
 
 	/**
 	 * 
@@ -136,9 +171,9 @@ public class CoreApi {
 		//make sure the new task name is unique among this user's tasks
 		List<String>taskNames = ApiUtil.getAllTaskNamesByUser(userProfile.get().getId());
 		if (taskNames.contains(name.toLowerCase())) {
-			response.status(400);
-			String errorMsg = "A task named " + name + " already exists. Please enter a different name.";			
-			return errorMsg;
+			response.status(200);
+			String errorMsg = "A task named " + name + " already exists. Please enter a different name.";
+			return "{\"message\": \"" + errorMsg + "\"}";
 		}
 		
 		

--- a/src/main/java/gov/epa/bencloud/api/util/ApiUtil.java
+++ b/src/main/java/gov/epa/bencloud/api/util/ApiUtil.java
@@ -322,4 +322,23 @@ public class ApiUtil {
 	public static Integer getMultipartFormParameterAsInteger(Request request, String paramName) {
 		return Integer.valueOf(getMultipartFormParameterAsString(request, paramName));
 	}
+	
+	/**
+	 * 
+	 * @param userId
+	 * @return a list of all task names for a given user id.
+	 */
+	public static List<String> getAllTaskNamesByUser(String userId) {
+		if(userId == null) {
+			return null;
+		}
+
+		List<String> allTaskNames = DSL.using(JooqUtil.getJooqConfiguration())
+				.select(TASK_CONFIG.NAME)
+				.from(TASK_CONFIG)
+				.where(TASK_CONFIG.USER_ID.equal(userId))
+				.orderBy(TASK_CONFIG.USER_ID)
+				.fetch(TASK_CONFIG.NAME);
+		return allTaskNames;
+	}
 }

--- a/src/main/java/gov/epa/bencloud/server/routes/ApiRoutes.java
+++ b/src/main/java/gov/epa/bencloud/server/routes/ApiRoutes.java
@@ -409,11 +409,21 @@ public class ApiRoutes extends RoutesBase {
 			String ret = CoreApi.postTaskConfig(request, response, getUserProfile(request, response));
 
 			if(response.status() == 400) {
-				return CoreApi.getErrorResponseInvalidId(request, response);
+				//return CoreApi.getErrorResponseInvalidId(request, response);
+				response.type("application/json");
+				return ret;
 			}
 
 			response.type("application/json");
 			return ret;
+
+		});
+		
+		/*
+		 * DELETE selected template
+		 */
+		service.delete(apiPrefix + "/task-configs/:id", (request, response) -> {
+			return CoreApi.deleteTaskConfig(request, response, getUserProfile(request, response));
 
 		});
 


### PR DESCRIPTION
BCD-211: Add the ability to delete templates. Prevent users from saving an analysis template with a name that has already been used by the current user.
It's currently missing the feature to allow users to rename a template. Will add that feature later.