### PR TITLE
BWD-59 Update DELETE /batch-tasks/:id to support export tasks + bug fix

### DIFF
--- a/src/main/java/gov/epa/bencloud/api/util/ApiUtil.java
+++ b/src/main/java/gov/epa/bencloud/api/util/ApiUtil.java
@@ -596,10 +596,11 @@ public class ApiUtil {
 				TaskUtil.deleteHifResults(uuid, true);
 			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals("Valuation")) {
 				TaskUtil.deleteValuationResults(uuid, true);
+			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals("Exposure")) {
+				TaskUtil.deleteExposureResults(uuid, true);
+			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals("Result Export")) {
+				TaskUtil.deleteResultExportResults(uuid, true);
 			}
-			 else if (record.get(TASK_COMPLETE.TASK_TYPE).equals("Exposure")) {
-					TaskUtil.deleteExposureResults(uuid, true);
-				}
 		}
 		
 		//delete from batch_task table	

--- a/src/main/java/gov/epa/bencloud/server/tasks/local/ResultExportTaskRunnable.java
+++ b/src/main/java/gov/epa/bencloud/server/tasks/local/ResultExportTaskRunnable.java
@@ -594,9 +594,11 @@ public class ResultExportTaskRunnable implements Runnable {
 			}
 			
 			String fileMetadata = "{\"name\":\"" + zipFileName + ".zip\"}";
-			Integer fsid = FilestoreUtil.putFile(new FileInputStream(tmpZipFile), zipFileName + ".zip", Constants.FILE_TYPE_RESULT_EXPORT, task.getUserIdentifier(), fileMetadata);
-			resultExportTaskConfig.filestoreId = fsid;
-			
+			try (FileInputStream fis = new FileInputStream(tmpZipFile)) {
+				Integer fsid = FilestoreUtil.putFile(fis, zipFileName + ".zip", Constants.FILE_TYPE_RESULT_EXPORT, task.getUserIdentifier(), fileMetadata);
+				resultExportTaskConfig.filestoreId = fsid;
+			} // Ending try will close FileInputStream before delete
+
 			Files.delete(Paths.get(tmpZipFile.getPath()));
 			
 			TaskQueue.updateTaskParameters(task.getUuid(), mapper.writeValueAsString(resultExportTaskConfig));


### PR DESCRIPTION
Handle deletion of “Result Export” tasks and remove file.

Also, fix a bug where temp zip file was not getting deleted which was throwing an exception which was causing the filestoreId to not be stored in the completed task.