### PR TITLE
Block Crosswalks and Replace Strings with Constants

### DIFF
--- a/src/main/java/gov/epa/bencloud/api/CrosswalksApi.java
+++ b/src/main/java/gov/epa/bencloud/api/CrosswalksApi.java
@@ -1,6 +1,10 @@
 package gov.epa.bencloud.api;
 
 import static gov.epa.bencloud.server.database.jooq.data.Tables.*;
+
+import java.util.Arrays;
+import java.util.List;
+
 import gov.epa.bencloud.server.database.JooqUtil;
 import gov.epa.bencloud.server.database.jooq.data.tables.records.CrosswalkDatasetRecord;
 import org.jooq.impl.DSL;
@@ -88,6 +92,14 @@ public class CrosswalksApi {
 		if (sourceId == targetId) {
 			log.debug("No need for crosswalk as source and target are the same: " + sourceId);
 			return true;
+		}
+
+		List<Integer> gridSourceIds2010 = Arrays.asList(18, 19, 20);
+		List<Integer> gridTargetIds2010 = Arrays.asList(18, 19);
+		List<Integer> gridIds2020 = Arrays.asList(68, 69, 70, 83);
+		if ((gridSourceIds2010.contains(sourceId) && gridIds2020.contains(targetId)) || (gridIds2020.contains(sourceId) || gridTargetIds2010.contains(targetId))) {
+			log.error("Do not create crosswalks for certain grid definitions");
+			return false;
 		}
 
 		DSLContext dslContext = DSL.using(JooqUtil.getJooqConfiguration());

--- a/src/main/java/gov/epa/bencloud/api/util/ApiUtil.java
+++ b/src/main/java/gov/epa/bencloud/api/util/ApiUtil.java
@@ -45,6 +45,7 @@ import org.pac4j.core.profile.UserProfile;
 
 import static gov.epa.bencloud.server.database.jooq.data.Tables.*;
 
+import gov.epa.bencloud.Constants;
 import gov.epa.bencloud.api.CoreApi;
 import gov.epa.bencloud.api.CrosswalksApi;
 import gov.epa.bencloud.api.HIFApi;
@@ -592,13 +593,13 @@ public class ApiUtil {
 			//TODO: Do we need to remove children task results before removing parent tasks? 
 			// Valuation results have hif tasks as their parents but both hif and valuation results have the same task_batch_id.
 			String uuid = record.getValue(TASK_COMPLETE.TASK_UUID);
-			if (record.get(TASK_COMPLETE.TASK_TYPE).equals("HIF")) {
+			if (record.get(TASK_COMPLETE.TASK_TYPE).equals(Constants.TASK_TYPE_HIF)) {
 				TaskUtil.deleteHifResults(uuid, true);
-			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals("Valuation")) {
+			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals(Constants.TASK_TYPE_VALUATION)) {
 				TaskUtil.deleteValuationResults(uuid, true);
-			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals("Exposure")) {
+			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals(Constants.TASK_TYPE_EXPOSURE)) {
 				TaskUtil.deleteExposureResults(uuid, true);
-			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals("Result Export")) {
+			} else if (record.get(TASK_COMPLETE.TASK_TYPE).equals(Constants.TASK_TYPE_RESULT_EXPORT)) {
 				TaskUtil.deleteResultExportResults(uuid, true);
 			}
 		}


### PR DESCRIPTION
Don't create crosswalks for certain grid definitions

Replace strings with constants