### PR TITLE
Fix post "/batch-tasks/:id/export" returning 404 error on success

### DIFF
--- a/src/main/java/gov/epa/bencloud/api/TaskApi.java
+++ b/src/main/java/gov/epa/bencloud/api/TaskApi.java
@@ -1759,18 +1759,15 @@ public class TaskApi {
 	
 			} catch (NumberFormatException e) {
 				e.printStackTrace();
-				CoreApi.getErrorResponseInvalidId(request, response);
-				return null;
+				return CoreApi.getErrorResponseInvalidId(request, response);
 			} catch (IllegalArgumentException e) {
 				e.printStackTrace();
-				CoreApi.getErrorResponseInvalidId(request, response);
-				return null;
+				return CoreApi.getErrorResponseInvalidId(request, response);
 			}
 			
 			BatchTaskConfig batchTaskConfig = getTaskBatchConfigFromDb(batchId);
 			if(batchTaskConfig==null) {
-				response.status(400);
-				return null;
+				return CoreApi.getErrorResponseNotFound(request, response);
 			}
 			
 			// If a gridId wasn't provided, look up the baseline AQ grid grid for this resultset
@@ -1780,8 +1777,7 @@ public class TaskApi {
 				}
 			} catch (NullPointerException e) {
 				e.printStackTrace();
-				response.status(400);
-				return null;
+				return CoreApi.getErrorResponse(request, response, 404, "Grid definition id not found");
 			}
 				
 			ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/gov/epa/bencloud/server/routes/ApiRoutes.java
+++ b/src/main/java/gov/epa/bencloud/server/routes/ApiRoutes.java
@@ -587,13 +587,7 @@ public class ApiRoutes extends RoutesBase {
 		 *  
 		 */	
 		service.post(apiPrefix + "/batch-tasks/:id/export", (request, response) -> {
-			TaskApi.postResultExportTask(request, response, getUserProfile(request, response));
-			
-			if(response.status() == 400) {
-				return CoreApi.getErrorResponseInvalidId(request, response);
-			}
-
-			return null;
+			return TaskApi.postResultExportTask(request, response, getUserProfile(request, response));
 		});
 		
 		service.get(apiPrefix + "/task-configs", (request, response) -> {


### PR DESCRIPTION
When the post function returned null, the status would be overridden to 404. By setting a return value, this avoids that situation.