### PR TITLE
BWD-87 Fix: Some result exports are including blank task logs

### DIFF
--- a/src/main/java/gov/epa/bencloud/api/TaskApi.java
+++ b/src/main/java/gov/epa/bencloud/api/TaskApi.java
@@ -1798,6 +1798,7 @@ public class TaskApi {
 			taskParamsNode.put("includeExposure", includeExposure);
 			taskParamsNode.put("taskUuid", taskUuid);
 			taskParamsNode.put("uuidType", uuidType);			
+			taskParamsNode.put("isAdmin", CoreApi.isAdmin(userProfile));			
 
 			ArrayNode gridsNode = taskParamsNode.putArray("gridIds");
 			for (int g : gridIds) {

--- a/src/main/java/gov/epa/bencloud/api/model/ResultExportTaskConfig.java
+++ b/src/main/java/gov/epa/bencloud/api/model/ResultExportTaskConfig.java
@@ -50,6 +50,7 @@ public class ResultExportTaskConfig {
 	public String taskUuid;
 	public String uuidType;
 	public Integer[] gridIds;
+	public Boolean isAdmin;
 	
 	/*
 	 * Default constructor

--- a/src/main/java/gov/epa/bencloud/server/tasks/local/ResultExportTaskRunnable.java
+++ b/src/main/java/gov/epa/bencloud/server/tasks/local/ResultExportTaskRunnable.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Map.Entry;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -51,6 +52,8 @@ import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.mariuszgromada.math.mxparser.Expression;
 import org.mariuszgromada.math.mxparser.mXparser;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.UserProfile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,6 +155,13 @@ public class ResultExportTaskRunnable implements Runnable {
 			Boolean includeExposure = resultExportTaskConfig.includeExposure;
 			String taskUuid = resultExportTaskConfig.taskUuid;
 			String uuidType = resultExportTaskConfig.uuidType;
+
+			CommonProfile profile = new CommonProfile();
+			profile.setId(resultExportTaskConfig.userId);
+			if (resultExportTaskConfig.isAdmin) {
+				profile.addRole(Constants.ROLE_ADMIN);
+			}
+			Optional<UserProfile> userProfile = Optional.of(profile);
 			
 			BatchTaskConfig batchTaskConfig = TaskApi.getTaskBatchConfigFromDb(batchId);
 			
@@ -296,7 +306,7 @@ public class ResultExportTaskRunnable implements Runnable {
 							}
 						ExposureTaskLog efTaskLog = ExposureUtil.getTaskLog(exposureResultDatasetId);
 						batchTaskLog.append(System.getProperty("line.separator"));
-						//batchTaskLog.append(efTaskLog.toString(userProfile));
+						batchTaskLog.append(efTaskLog.toString(userProfile));
 					}				
 				}					
 			}
@@ -447,7 +457,7 @@ public class ResultExportTaskRunnable implements Runnable {
 							}
 						HIFTaskLog hifTaskLog = HIFUtil.getTaskLog(hifResultDatasetId);
 						batchTaskLog.append(System.getProperty("line.separator"));
-						//batchTaskLog.append(hifTaskLog.toString(userProfile));
+						batchTaskLog.append(hifTaskLog.toString(userProfile));
 					}				
 				}					
 			}


### PR DESCRIPTION
Adding the task log was commented out for HIF and Exposure exports, presumably because they required UserProfile. So I created a UserProfile with the relevant info: it is only being used in AirQualityApi.getAirQualityLayerDefinition() for its userId and isAdmin.